### PR TITLE
Add build number check for problem packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dagster-green.svg)](https://anaconda.org/conda-forge/dagster) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster.svg)](https://anaconda.org/conda-forge/dagster) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster.svg)](https://anaconda.org/conda-forge/dagster) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster.svg)](https://anaconda.org/conda-forge/dagster) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--aws-green.svg)](https://anaconda.org/conda-forge/dagster-aws) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-aws.svg)](https://anaconda.org/conda-forge/dagster-aws) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-aws.svg)](https://anaconda.org/conda-forge/dagster-aws) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-aws.svg)](https://anaconda.org/conda-forge/dagster-aws) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--celery-green.svg)](https://anaconda.org/conda-forge/dagster-celery) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-celery.svg)](https://anaconda.org/conda-forge/dagster-celery) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-celery.svg)](https://anaconda.org/conda-forge/dagster-celery) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-celery.svg)](https://anaconda.org/conda-forge/dagster-celery) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--dask-green.svg)](https://anaconda.org/conda-forge/dagster-dask) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-dask.svg)](https://anaconda.org/conda-forge/dagster-dask) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-dask.svg)](https://anaconda.org/conda-forge/dagster-dask) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-dask.svg)](https://anaconda.org/conda-forge/dagster-dask) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--gcp-green.svg)](https://anaconda.org/conda-forge/dagster-gcp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-gcp.svg)](https://anaconda.org/conda-forge/dagster-gcp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-gcp.svg)](https://anaconda.org/conda-forge/dagster-gcp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-gcp.svg)](https://anaconda.org/conda-forge/dagster-gcp) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--graphql-green.svg)](https://anaconda.org/conda-forge/dagster-graphql) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-graphql.svg)](https://anaconda.org/conda-forge/dagster-graphql) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-graphql.svg)](https://anaconda.org/conda-forge/dagster-graphql) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-graphql.svg)](https://anaconda.org/conda-forge/dagster-graphql) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dagster--pyspark-green.svg)](https://anaconda.org/conda-forge/dagster-pyspark) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagster-pyspark.svg)](https://anaconda.org/conda-forge/dagster-pyspark) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagster-pyspark.svg)](https://anaconda.org/conda-forge/dagster-pyspark) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagster-pyspark.svg)](https://anaconda.org/conda-forge/dagster-pyspark) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dagstermill-green.svg)](https://anaconda.org/conda-forge/dagstermill) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dagstermill.svg)](https://anaconda.org/conda-forge/dagstermill) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dagstermill.svg)](https://anaconda.org/conda-forge/dagstermill) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dagstermill.svg)](https://anaconda.org/conda-forge/dagstermill) |
 
 Installing dagster
 ==================
@@ -145,10 +149,10 @@ Installing `dagster` from the `conda-forge` channel can be achieved by adding `c
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `dagster, dagster-celery, dagster-dask, dagster-graphql` can be installed with:
+Once the `conda-forge` channel has been enabled, `dagster, dagster-aws, dagster-celery, dagster-dask, dagster-gcp, dagster-graphql, dagster-pyspark, dagstermill` can be installed with:
 
 ```
-conda install dagster dagster-celery dagster-dask dagster-graphql
+conda install dagster dagster-aws dagster-celery dagster-dask dagster-gcp dagster-graphql dagster-pyspark dagstermill
 ```
 
 It is possible to list all of the versions of `dagster` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -370,7 +370,7 @@ outputs:
       license_file: dagster-gcp/LICENSE
       summary: "Package for GCP-specific Dagster framework solid and resource components."
 
-  issues with python 3.8
+  # issues with python 3.8
   - name: dagster-pyspark
     build:
       number: {{ build_number }}
@@ -442,49 +442,49 @@ outputs:
       summary: "A Dagster integration for papermill"
 
   # issues with python 3.8
-  - name: dagster-airflow
-    build:
-      number: {{ build_number }}
-      noarch: python
-      script: cd dagster-airflow && {{ PYTHON }} -m pip install . -vv --no-deps
-      entry_points:
-        - dagster-airflow = dagster_airflow.cli:main
+  # - name: dagster-airflow
+  #   build:
+  #     number: {{ build_number }}
+  #     noarch: python
+  #     script: cd dagster-airflow && {{ PYTHON }} -m pip install . -vv --no-deps
+  #     entry_points:
+  #       - dagster-airflow = dagster_airflow.cli:main
 
-    requirements:
-      host:
-        - pip
-        - python <3.8.0a0
-      run:
-        - airflow
-        - dagster {{ version }}.*
-        - dagster-graphql {{ version }}.*
-        - docker-py
-        - python <3.8.0a0
-        - python-dateutil >=2.8.0
-        - six
-        - werkzeug <1.0.0a0
+  #   requirements:
+  #     host:
+  #       - pip
+  #       - python <3.8.0a0
+  #     run:
+  #       - airflow
+  #       - dagster {{ version }}.*
+  #       - dagster-graphql {{ version }}.*
+  #       - docker-py
+  #       - python <3.8.0a0
+  #       - python-dateutil >=2.8.0
+  #       - six
+  #       - werkzeug <1.0.0a0
 
-    test:
-      # presently has upstream issues with:
-      # python-daemon 2.1.2 requires docutils, which is not installed.
-      # apache-airflow 1.10.7 has requirement flask-admin==1.5.4, but you have flask-admin 1.5.3.
-      # apache-airflow 1.10.7 has requirement flask-appbuilder~=2.2; python_version >= "3.6", but you have flask-appbuilder 1.12.5.
-      # requires:
-      #   - pip
-      requires:
-        - python <3.8.0a0
-      imports:
-        - dagster_airflow
-      commands:
-        - dagster-airflow --help
-        # - python -m pip check
+  #   test:
+  #     # presently has upstream issues with:
+  #     # python-daemon 2.1.2 requires docutils, which is not installed.
+  #     # apache-airflow 1.10.7 has requirement flask-admin==1.5.4, but you have flask-admin 1.5.3.
+  #     # apache-airflow 1.10.7 has requirement flask-appbuilder~=2.2; python_version >= "3.6", but you have flask-appbuilder 1.12.5.
+  #     # requires:
+  #     #   - pip
+  #     requires:
+  #       - python <3.8.0a0
+  #     imports:
+  #       - dagster_airflow
+  #     commands:
+  #       - dagster-airflow --help
+  #       # - python -m pip check
 
-    about:
-      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-airflow"
-      license: Apache-2.0
-      license_family: APACHE
-      license_file: dagster-airflow/LICENSE
-      summary: "Airflow plugin for Dagster"
+  #   about:
+  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-airflow"
+  #     license: Apache-2.0
+  #     license_family: APACHE
+  #     license_file: dagster-airflow/LICENSE
+  #     summary: "Airflow plugin for Dagster"
 
   # issues with python 3.8
   - name: dagster-aws

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.7.1" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # TODO: more elegant way to get at CONDA_SUBDIR
 {% set on_linux_py37 = PY_VER == "3.7" and "linux-64" in compiler("c") %}
@@ -24,7 +24,8 @@ source:
 
   {% if on_linux_py37 %}
   # these are problematic, and presently build only/most reliably on linux/37
-  # along with their dependencies
+  # along with their dependencies. always download them anyway so they can be found
+  # when rendering the recipe to fetch the shas
   - folder: dagster-airflow
     url: "https://pypi.io/packages/source/d/dagster-airflow/dagster-airflow-{{ version }}.tar.gz"
     sha256: 19ee4d49aaba51cc68d445c3ca28d9bdfe797b1f05310e2f612ceaa89156817f
@@ -258,94 +259,6 @@ outputs:
   {% endif %}
 
   {% if on_linux_py37 %}
-  # issues with python 3.8
-  # - name: dagster-airflow
-  #   build:
-  #     number: {{ build_number }}
-  #     noarch: python
-  #     script: cd dagster-airflow && {{ PYTHON }} -m pip install . -vv --no-deps
-  #     entry_points:
-  #       - dagster-airflow = dagster_airflow.cli:main
-
-  #   requirements:
-  #     host:
-  #       - pip
-  #       - python <3.8.0a0
-  #     run:
-  #       - airflow
-  #       - dagster {{ version }}.*
-  #       - dagster-graphql {{ version }}.*
-  #       - docker-py
-  #       - python <3.8.0a0
-  #       - python-dateutil >=2.8.0
-  #       - six
-  #       - werkzeug <1.0.0a0
-
-  #   test:
-  #     # presently has upstream issues with:
-  #     # python-daemon 2.1.2 requires docutils, which is not installed.
-  #     # apache-airflow 1.10.7 has requirement flask-admin==1.5.4, but you have flask-admin 1.5.3.
-  #     # apache-airflow 1.10.7 has requirement flask-appbuilder~=2.2; python_version >= "3.6", but you have flask-appbuilder 1.12.5.
-  #     # requires:
-  #     #   - pip
-  #     requires:
-  #       - python <3.8.0a0
-  #     imports:
-  #       - dagster_airflow
-  #     commands:
-  #       - dagster-airflow --help
-  #       # - python -m pip check
-
-  #   about:
-  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-airflow"
-  #     license: Apache-2.0
-  #     license_family: APACHE
-  #     license_file: dagster-airflow/LICENSE
-  #     summary: "Airflow plugin for Dagster"
-
-  # issues with python 3.8
-  # - name: dagster-aws
-  #   build:
-  #     noarch: python
-  #     number: {{ build_number }}
-  #     entry_points:
-  #       - dagster-aws = dagster_aws.cli.cli:main
-  #     script: cd dagster-aws && {{ PYTHON }} -m pip install . -vv --no-deps
-
-  #   requirements:
-  #     host:
-  #       - pip
-  #       - python <3.8.0a0
-  #     run:
-  #       - boto3 1.9.*
-  #       - dagster {{ version }}.*
-  #       - mock
-  #       - python <3.8.0a0
-  #       - requests
-  #       - terminaltables
-
-  #   test:
-  #     requires:
-  #       - dagster-pyspark
-  #       - pip
-  #       - python <3.8.0
-  #     imports:
-  #       - dagster_aws
-  #       - dagster_aws.cli
-  #       - dagster_aws.cloudwatch
-  #       # - dagster_aws.emr
-  #       - dagster_aws.s3
-  #     commands:
-  #       - dagster-aws --help
-  #       - python -m pip check
-
-  #   about:
-  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws"
-  #     license: Apache Software
-  #     license_family: APACHE
-  #     license_file: dagster-aws/LICENSE
-  #     summary: "Package for AWS-specific Dagster framework solid and resource components."
-
   - name: dagster-celery
     build:
       number: {{ build_number }}
@@ -366,14 +279,13 @@ outputs:
         - python
 
     test:
-      # missing transient dependency (billiard >=3.6.1)
-      # requires:
-      #   - pip
+      requires:
+        - pip
       imports:
         - dagster_celery
       commands:
         - dagster-celery --help
-        # - python -m pip check
+        - python -m pip check
 
     about:
       home: "https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-celery"
@@ -415,116 +327,207 @@ outputs:
       license_family: APACHE
       license_file: dagster-dask/LICENSE
       summary: "Package for using Dask as Dagster's execution engine."
+  {% endif %}
 
+  {% if on_linux_py37 and build_number > 0 %}
+  # these _would_ build on py37_0, except conda-build tries to test them with py38
   # issues with win/python 2.7
-  # - name: dagster-gcp
-  #   build:
-  #     number: {{ build_number }}
-  #     noarch: python
-  #     script: cd dagster-gcp && {{ PYTHON }} -m pip install . -vv --no-deps
+  - name: dagster-gcp
+    build:
+      number: {{ build_number }}
+      noarch: python
+      script: cd dagster-gcp && {{ PYTHON }} -m pip install . -vv --no-deps
 
-  #   requirements:
-  #     host:
-  #       - pip
-  #       - python <3.8.0a0
-  #     run:
-  #       - dagster
-  #       - dagster-pandas
-  #       - google-api-python-client
-  #       - google-cloud-bigquery >=1.19
-  #       - google-cloud-storage
-  #       - google-resumable-media
-  #       - oauth2client
-  #       - python <3.8.0a0
+    requirements:
+      host:
+        - pip
+        - python <3.8.0a0
+      run:
+        - dagster
+        - dagster-pandas
+        - google-api-python-client
+        - google-cloud-bigquery >=1.19
+        - google-cloud-storage
+        - google-resumable-media
+        - oauth2client
+        - python <3.8.0a0
 
-  #   test:
-  #     requires:
-  #       - pip
-  #     imports:
-  #       - dagster_gcp
-  #       - dagster_gcp.bigquery
-  #       - dagster_gcp.dataproc
-  #       - dagster_gcp.gcs
-  #     commands:
-  #       - python -m pip check
+    test:
+      requires:
+        - pip
+      imports:
+        - dagster_gcp
+        - dagster_gcp.bigquery
+        - dagster_gcp.dataproc
+        - dagster_gcp.gcs
+      commands:
+        - python -m pip check
 
-  #   about:
-  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-gcp"
-  #     license: Apache-2.0
-  #     license_family: APACHE
-  #     license_file: dagster-gcp/LICENSE
-  #     summary: "Package for GCP-specific Dagster framework solid and resource components."
+    about:
+      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-gcp"
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: dagster-gcp/LICENSE
+      summary: "Package for GCP-specific Dagster framework solid and resource components."
 
-  # issues with python 3.8
-  # - name: dagster-pyspark
-  #   build:
-  #     number: {{ build_number }}
-  #     noarch: python
-  #     script: cd dagster-pyspark && {{ PYTHON }} -m pip install . -vv --no-deps
+  issues with python 3.8
+  - name: dagster-pyspark
+    build:
+      number: {{ build_number }}
+      noarch: python
+      script: cd dagster-pyspark && {{ PYTHON }} -m pip install . -vv --no-deps
 
-  #   requirements:
-  #     host:
-  #       - pip
-  #       - python <3.8.0a0
-  #     run:
-  #       - dagster {{ version }}.*
-  #       - dagster-spark {{ version }}.*
-  #       - pyspark
-  #       - python <3.8.0a0
+    requirements:
+      host:
+        - pip
+        - python <3.8.0a0
+      run:
+        - dagster {{ version }}.*
+        - dagster-spark {{ version }}.*
+        - pyspark
+        - python <3.8.0a0
 
-  #   test:
-  #     requires:
-  #       - pip
-  #     imports:
-  #       - dagster_pyspark
-  #     commands:
-  #       - python -m pip check
+    test:
+      requires:
+        - pip
+      imports:
+        - dagster_pyspark
+      commands:
+        - python -m pip check
 
-  #   about:
-  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-framework/pyspark"
-  #     license: Apache-2.0
-  #     license_family: APACHE
-  #     license_file: dagster-pyspark/LICENSE
-  #     summary: "Package for PySpark Dagster framework components."
+    about:
+      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-framework/pyspark"
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: dagster-pyspark/LICENSE
+      summary: "Package for PySpark Dagster framework components."
 
   # issues with python 2.7
-  # - name: dagstermill
-  #   build:
-  #     number: {{ build_number }}
-  #     noarch: python
-  #     script: cd dagstermill && {{ PYTHON }} -m pip install . -vv --no-deps
-  #     entry_points:
-  #       - dagstermill = dagstermill.cli:main
+  - name: dagstermill
+    build:
+      number: {{ build_number }}
+      noarch: python
+      script: cd dagstermill && {{ PYTHON }} -m pip install . -vv --no-deps
+      entry_points:
+        - dagstermill = dagstermill.cli:main
 
-  #   requirements:
-  #     host:
-  #       - pip
-  #       - python >=3.5
-  #     run:
-  #       - dagster {{ version }}.*
-  #       - dagster-pandas
-  #       - ipykernel >=4.9.0
-  #       - nteract-scrapbook >=0.2.0
-  #       - papermill >=1.0.0,<2.0.0
-  #       - python >=3.5
-  #       - scikit-learn >=0.19.0
-  #       - six
+    requirements:
+      host:
+        - pip
+        - python >=3.5
+      run:
+        - dagster {{ version }}.*
+        - dagster-pandas
+        - ipykernel >=4.9.0
+        - nteract-scrapbook >=0.2.0
+        - papermill >=1.0.0,<2.0.0
+        - python >=3.5
+        - scikit-learn >=0.19.0
+        - six
 
-  #   test:
-  #     requires:
-  #       - pip
-  #     imports:
-  #       - dagstermill
-  #     commands:
-  #       - dagstermill --help
-  #       - python -m pip check
+    test:
+      requires:
+        - pip
+      imports:
+        - dagstermill
+      commands:
+        - dagstermill --help
+        - python -m pip check
 
-  #   about:
-  #     home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagstermill"
-  #     license: Apache-2.0
-  #     license_family: APACHE
-  #     license_file: dagstermill/LICENSE
-  #     summary: "A Dagster integration for papermill"
+    about:
+      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagstermill"
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: dagstermill/LICENSE
+      summary: "A Dagster integration for papermill"
+
+  # issues with python 3.8
+  - name: dagster-airflow
+    build:
+      number: {{ build_number }}
+      noarch: python
+      script: cd dagster-airflow && {{ PYTHON }} -m pip install . -vv --no-deps
+      entry_points:
+        - dagster-airflow = dagster_airflow.cli:main
+
+    requirements:
+      host:
+        - pip
+        - python <3.8.0a0
+      run:
+        - airflow
+        - dagster {{ version }}.*
+        - dagster-graphql {{ version }}.*
+        - docker-py
+        - python <3.8.0a0
+        - python-dateutil >=2.8.0
+        - six
+        - werkzeug <1.0.0a0
+
+    test:
+      # presently has upstream issues with:
+      # python-daemon 2.1.2 requires docutils, which is not installed.
+      # apache-airflow 1.10.7 has requirement flask-admin==1.5.4, but you have flask-admin 1.5.3.
+      # apache-airflow 1.10.7 has requirement flask-appbuilder~=2.2; python_version >= "3.6", but you have flask-appbuilder 1.12.5.
+      # requires:
+      #   - pip
+      requires:
+        - python <3.8.0a0
+      imports:
+        - dagster_airflow
+      commands:
+        - dagster-airflow --help
+        # - python -m pip check
+
+    about:
+      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster-airflow"
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: dagster-airflow/LICENSE
+      summary: "Airflow plugin for Dagster"
+
+  # issues with python 3.8
+  - name: dagster-aws
+    build:
+      noarch: python
+      number: {{ build_number }}
+      entry_points:
+        - dagster-aws = dagster_aws.cli.cli:main
+      script: cd dagster-aws && {{ PYTHON }} -m pip install . -vv --no-deps
+
+    requirements:
+      host:
+        - pip
+        - python <3.8.0a0
+      run:
+        - boto3 1.9.*
+        - dagster {{ version }}.*
+        - mock
+        - python <3.8.0a0
+        - requests
+        - terminaltables
+
+    test:
+      requires:
+        - dagster-pyspark
+        - pip
+        - python <3.8.0
+      imports:
+        - dagster_aws
+        - dagster_aws.cli
+        - dagster_aws.cloudwatch
+        # - dagster_aws.emr
+        - dagster_aws.s3
+      commands:
+        - dagster-aws --help
+        - python -m pip check
+
+    about:
+      home: "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws"
+      license: Apache Software
+      license_family: APACHE
+      license_file: dagster-aws/LICENSE
+      summary: "Package for AWS-specific Dagster framework solid and resource components."
   {% endif %}
 
   {% if on_linux_py38 %}


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Like #16, this re-enables the problematic packages, but it moves them to a check of `build_number > 0`. Future releases would then be:
- allow the bot to bump the version up and the build number back down to `0`
  - fix all the shas #14
  - build
  - merge
- wait for the builds
- make a new manual pr
  - bump the build_number to `1`
  - build
  - merge

I have no idea what's up with airflow, and have just commented it out for now.